### PR TITLE
Fix a couple of intermittent errors in TotallyCoolPix

### DIFF
--- a/lib/scrapers.py
+++ b/lib/scrapers.py
@@ -351,6 +351,7 @@ class TotallyCoolPix(BasePlugin):
                 raise
 
         self._photos[album_url] = []
+        tree = tree.find('div', {'class': 'main-content single-view'})
         album_title = tree.find('h2').string
         for id, photo in enumerate(tree.findAll('div', {'class': 'image'})):
             img = photo.find('img')

--- a/lib/scrapers.py
+++ b/lib/scrapers.py
@@ -357,7 +357,11 @@ class TotallyCoolPix(BasePlugin):
             img = photo.find('img')
             if not img:
                 continue
-            description = self._collapse(photo.find('p', {'class': 'info-txt'}).contents)
+            description = photo.find('p', {'class': 'info-txt'})
+            if not description:
+                # This is the title image, which is duplicated later in the body with a description
+                continue
+            description = self._collapse(description.contents)
             self._photos[album_url].append({
                 'title': '%d - %s' % (id + 1, album_title),
                 'album_title': album_title,

--- a/lib/scrapers.py
+++ b/lib/scrapers.py
@@ -353,7 +353,6 @@ class TotallyCoolPix(BasePlugin):
         self._photos[album_url] = []
         album_title = tree.find('h2').string
         for id, photo in enumerate(tree.findAll('div', {'class': 'image'})):
-            print photo
             img = photo.find('img')
             if not img:
                 continue


### PR DESCRIPTION
One is an occasional infinite redirect when requesting a URL. The same URL may work some time later, so it just returns an empty list when this happens.

The other happens when grabbing the title image, which it then skips because the same image will be elsewhere on the page with a description.
